### PR TITLE
Index elements correctly

### DIFF
--- a/lib/Digest/BubbleBabble.pm6
+++ b/lib/Digest/BubbleBabble.pm6
@@ -105,7 +105,7 @@ method decode(Blob $fingerprint --> Blob) {
         error => "invalid fingerprint length"
     ).throw if +$fingerprint % 6 != 5;
 
-    my @tuples = $fingerprint[1..^*].rotor(6, :partial);
+    my @tuples = $fingerprint[1..*-2].rotor(6, :partial);
     my Int $seed = 1;
     Blob.new: gather for @tuples.kv -> $i, @tuple {
         my Int @bytes = self!decode-tuple(@tuple).grep(Int:D);
@@ -139,7 +139,7 @@ method validate(Blob $fingerprint --> Bool) {
     return False if (+$fingerprint % 6 != 5);
 
     my Int $seed   = 1;
-    my     @tuples = $fingerprint[1..^*].rotor(6, :partial);
+    my     @tuples = $fingerprint[1..*-2].rotor(6, :partial);
     for @tuples -> @tuple {
         my Int @bytes = self!decode-tuple(@tuple).grep(Int:D);
         if +@bytes >= 5 {


### PR DESCRIPTION
`[1,2,3][1..^*].say` is (2 3), not (2), meaning that `^` in that case
does nothing. It used to work because of a bug which was recently
fixed¹. The right way to do it is to use `*-2`.

¹ – https://github.com/rakudo/rakudo/commit/35b69f074b9db3ffeb1638fc8a548fc2c0643d5a